### PR TITLE
fix: coalesce version to valid string

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -45,9 +45,9 @@ export function usePermit({
 		functionName: "version",
 	});
   
-  	const validatedVersionFromContract = [1, 2, '1', '2'].includes(versionFromContract)
-	    ? versionFromContract
-	    : null;
+  const validatedVersionFromContract = [1, 2, '1', '2'].includes(versionFromContract ?? "")
+		? versionFromContract
+		: null;
 
 	const version = permitVersion ?? validatedVersionFromContract ?? '1';
 	


### PR DESCRIPTION
The previous version fix had a small type error.  Also fixed the indenting to align with style.